### PR TITLE
Fix for 0.47

### DIFF
--- a/packages/gl-react-native/android/src/main/java/fr/greweb/rngl/RNGLPackage.java
+++ b/packages/gl-react-native/android/src/main/java/fr/greweb/rngl/RNGLPackage.java
@@ -20,7 +20,8 @@ public class RNGLPackage implements ReactPackage {
 
     }
 
-    @Override
+    // Deprecated RN 0.47
+    // @Override
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }


### PR DESCRIPTION
createJSModules is now not required on Android from RN 0.47; this is required to build an app on 0.47 & should be backwards compatible.