### PR TITLE
Update build.gradle

### DIFF
--- a/packages/gl-react-native/android/build.gradle
+++ b/packages/gl-react-native/android/build.gradle
@@ -48,7 +48,7 @@ def findNdkBuildFullPath() {
     return new File(ndkDir, getNdkBuildName()).getAbsolutePath()
   }
   def ndkDir = android.hasProperty('plugin') ? android.plugin.ndkFolder :
-          plugins.getPlugin('com.android.library').sdkHandler.getNdkFolder()
+          project.android.ndkDirectory.absolutePath
   if (ndkDir) {
     return new File(ndkDir, getNdkBuildName()).getAbsolutePath()
   }


### PR DESCRIPTION
Quick fix that would make the project ready for gradle 2.3. I've tested it both with gradle 2.2.3 and 2.3, worked well in both.

[Reference](https://stackoverflow.com/questions/42644226/no-sdkhandler-field-in-libraryplugin-after-updating-to-build-tools-2-3-0)

(reason: I've updated my rn proj to sdk 26, build tools 26 and newer gradle)