### PR TITLE
When binding vertex shader attribute "_p", check if it's used actually

### DIFF
--- a/packages/gl-react/src/createSurface.js
+++ b/packages/gl-react/src/createSurface.js
@@ -538,7 +538,9 @@ export default ({
         prependGLSLName(vert, name),
         prependGLSLName(frag, name)
       );
-      shader.attributes._p.pointer();
+      for (let key in shader.attributes) {
+        shader.attributes[key].pointer();
+      }
       return shader;
     }
 


### PR DESCRIPTION
This just fixes the undefined part of the code, where vertex shader attribute is initialized (by calling gl.attributes._p.pointer() ...). This patch just checks if `gl.attributes._p` exists before calling `gl.attributes._p.pointer()`.

**Test plan**

If one implements vertex shader (e.g. `Shaders.create({ frag: ..., vert: ... }`), and NOT using `_p` it results an error that `gl.attributes._p.pointer()` - "Cannot call pointer() when _p is not defined.

**Motivation & background**

I know that the vertex shader functionality at the moment is a bit vague, however, this patch just fixes the current implementation not breaking when implementing custom vertex shader.

However, of course it would be nice to use more vertex attributes than the default `_p`. That's not the point on this PR. The first step on improving the current implementation obviously would be to setup mechanisms in place to disable the default behavior - so that attributes could be set "normal way", like `<Surface ref={this.setup} ... > ... </Surface>`. Second improvement would be to setup data structures so that one can setup the attributes similarly as uniforms are set in `<Node uniforms={{ ... }} ... />`.

I might give a try on making the gradual improvements, while still keeping the basic functionality. Of course I possibly need help and also it would be nice to know if anything like this is already planned :-) ...