### PR TITLE
webgltexture-loader-expo version updated to 0.11.0

### DIFF
--- a/packages/gl-react-expo/package.json
+++ b/packages/gl-react-expo/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "invariant": "^2.2.1",
     "prop-types": "^15.6.1",
-    "webgltexture-loader-expo": "^0.10.0"
+    "webgltexture-loader-expo": "^0.11.0"
   },
   "scripts": {
     "build": "cd ../.. && export PATH=$(npm bin):$PATH && cd - &&rm -rf lib && babel --source-maps -d lib src && flow-copy-source -v src lib",


### PR DESCRIPTION
webgltexture-loader-expo is not updated and gl-react-expo fails with Expo 32.0.0

This PR fixes #212