### PR TITLE
Updated GLView import statements and bumped version to 3.17.0

### DIFF
--- a/packages/gl-react-expo/package.json
+++ b/packages/gl-react-expo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gl-react-expo",
-  "version": "3.16.3",
+  "version": "3.17.0",
   "license": "MIT",
   "author": "Gaëtan Renaudeau <renaudeau.gaetan@gmail.com>",
   "description": "React Native via Expo implementation of gl-react, an universal React library to write and compose WebGL shaders",
@@ -23,6 +23,7 @@
   ],
   "peerDependencies": {
     "expo": "*",
+    "expo-gl": "*",
     "gl-react": "^3.13.0",
     "react": "*",
     "react-native": "*"

--- a/packages/gl-react-expo/package.json
+++ b/packages/gl-react-expo/package.json
@@ -22,7 +22,6 @@
     "LICENSE"
   ],
   "peerDependencies": {
-    "expo": "*",
     "expo-gl": "*",
     "gl-react": "^3.13.0",
     "react": "*",

--- a/packages/gl-react-expo/src/GLViewNative.js
+++ b/packages/gl-react-expo/src/GLViewNative.js
@@ -2,7 +2,7 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { View } from "react-native";
-import { GLView as EXGLView } from "expo";
+import { GLView as EXGLView } from "expo-gl";
 
 const propTypes = {
   onContextCreate: PropTypes.func.isRequired,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

I've updated the GLView import statements in the `gl-react-expo` package to alleviate warnings that are received when using Expo SDK 32+. I've bumped the version to **3.17.0** and added a peer dependency to `expo-gl`.

Removing the warnings is the secondary motivation for this PR. The primary motivation is that version **3.16.3** (the latest on NPM) still depends version **0.10.0** of the `webgltexture-loader-expo` package, see [https://registry.npmjs.org/gl-react-expo/-/gl-react-expo-3.16.3.tgz](https://registry.npmjs.org/gl-react-expo/-/gl-react-expo-3.16.3.tgz). Version **0.10.0** of the `webgltexture-loader-expo` breaks on Expo SDK 33 (not sure about 31 and 32) with null errors.

I'm hoping that you can merge this PR and publish the new version on NPM. If you're not satisfied with the PR, it would be great if you could simply bump the version of `gl-react-expo` and re-publish on NPM to fix the dependency issue (I won't lose any sleep over the console warnings).

Kind regards, and as always, huge thanks for your work!

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**

<!-- Demonstrate the code is solid. Please provide if possible an example and also make sure your changes is covered by tests -->