### PR TITLE
Import GLView from expo-gl rather than expo

### DIFF
--- a/packages/gl-react-expo/src/GLViewNative.js
+++ b/packages/gl-react-expo/src/GLViewNative.js
@@ -2,7 +2,7 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { View } from "react-native";
-import { GLView as EXGLView } from "expo";
+import { GLView as EXGLView } from "expo-gl";
 
 const propTypes = {
   onContextCreate: PropTypes.func.isRequired,


### PR DESCRIPTION
The Expo SDK changed in v33, so GLView now lives in expo-gl for everyone.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## What I'm doing
import GLView from `expo-gl` rather than `expo`

## but why
Well, I did `expo init` and then `expo install gl-react-expo` and it did not work at all, so that wasn't fun. This tiny change makes it fun again!

## How will you test this?
Seems like if it's building and any tests whatsoever are passing, it's working.