### PR TITLE
Bumps gl-react peer dependency to ^v4.0.0

### DIFF
--- a/packages/gl-react-dom/package.json
+++ b/packages/gl-react-dom/package.json
@@ -26,7 +26,7 @@
     "react": "global:React"
   },
   "peerDependencies": {
-    "gl-react": "^3.13.0",
+    "gl-react": "^4.0.0",
     "react": "*"
   },
   "devDependencies": {


### PR DESCRIPTION
**Summary**

Bumps the peer dependency of gl-react to `^v4.0.0` after noticing an npm cli warning when gl-react-dom v4.0.0 is used with gl-react v4.0.0 (the dev dependency version in package.json has already been bumped to v4.0.0).

**Test plan**

No changes to the code itself.