### PR TITLE
Add GLSL syntax highlighting in code examples

### DIFF
--- a/packages/cookbook-v2/src/index.css
+++ b/packages/cookbook-v2/src/index.css
@@ -34,4 +34,13 @@
   }
 }
 
+/* GLSL blocks inside template strings get a subtle dark bg across full width */
+.token.glsl-block {
+  background: rgba(0, 0, 0, 0.25);
+  border-radius: 3px;
+  display: block;
+  margin: 0 -1rem;
+  padding: 0.25rem 1rem;
+}
+
 

--- a/packages/cookbook-v2/src/pages/ExampleDetailPage.tsx
+++ b/packages/cookbook-v2/src/pages/ExampleDetailPage.tsx
@@ -7,6 +7,7 @@ import "prismjs/components/prism-typescript";
 import "prismjs/components/prism-jsx";
 import "prismjs/components/prism-tsx";
 import "prismjs/themes/prism-tomorrow.css";
+import "../utils/prismGlslTemplate";
 import { examples } from "../examples";
 import { ControlsPanel, getDefaults } from "../controls";
 import { Breadcrumb } from "../components/Breadcrumb";

--- a/packages/cookbook-v2/src/utils/prismGlslTemplate.ts
+++ b/packages/cookbook-v2/src/utils/prismGlslTemplate.ts
@@ -1,0 +1,39 @@
+import Prism from "prismjs";
+import "prismjs/components/prism-c";
+import "prismjs/components/prism-glsl";
+
+// Highlight GLSL inside tagged template literals (GLSL`...`)
+Prism.hooks.add("after-tokenize", (env) => {
+  if (env.language !== "tsx" && env.language !== "jsx") return;
+  walkTokens(env.tokens);
+});
+
+function walkTokens(tokens: (string | Prism.Token)[]) {
+  for (let i = 0; i < tokens.length; i++) {
+    const token = tokens[i];
+    if (typeof token === "string") continue;
+    if (token.type === "template-string") {
+      tryHighlightGlsl(token);
+    }
+    if (Array.isArray(token.content)) {
+      walkTokens(token.content);
+    }
+  }
+}
+
+function tryHighlightGlsl(token: Prism.Token) {
+  const content = token.content;
+  if (!Array.isArray(content)) return;
+
+  // Find the string part inside the template-string
+  for (let i = 0; i < content.length; i++) {
+    const part = content[i];
+    if (typeof part !== "string" && part.type === "string" && typeof part.content === "string") {
+      // Heuristic: check if it looks like GLSL
+      if (!/void\s+main\s*\(|gl_FragColor|precision\s+\w+p\s+float|out\s+vec4/.test(part.content)) continue;
+      // Re-tokenize as GLSL and mark the token
+      part.content = Prism.tokenize(part.content, Prism.languages.glsl);
+      part.type = "glsl-block";
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Prism.js hook that detects GLSL inside tagged template literals and applies GLSL grammar highlighting
- GLSL blocks get a subtle `rgba(0,0,0,0.25)` background spanning the full line width, visually separating shader code from JS/TSX
- Requires `prism-c` (dependency of `prism-glsl`), both already bundled in prismjs

## Test plan
- [x] `yarn vite build` — builds successfully
- [x] Manual: GLSL keywords (`vec4`, `uniform`, `sampler2D`, `main`) are colored
- [x] Manual: GLSL block has darker background across full width

🤖 Generated with [Claude Code](https://claude.com/claude-code)