### PR TITLE
chore: add npm publish workflow and release script

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,28 @@
+name: Publish to npm
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - run: corepack enable
+      - run: yarn install
+      - run: yarn build
+
+      - name: Publish packages
+        run: |
+          for pkg in gl-react gl-react-dom gl-react-expo gl-react-headless gl-react-native; do
+            yarn workspace $pkg npm publish
+          done
+        env:
+          YARN_NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,12 +8,15 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
       - uses: actions/checkout@v4
 
       - uses: actions/setup-node@v4
         with:
           node-version: 24
+          registry-url: 'https://registry.npmjs.org'
 
       - run: corepack enable
       - run: yarn install
@@ -22,7 +25,5 @@ jobs:
       - name: Publish packages
         run: |
           for pkg in gl-react gl-react-dom gl-react-expo gl-react-headless gl-react-native; do
-            yarn workspace $pkg npm publish
+            cd packages/$pkg && npm publish --provenance && cd ../..
           done
-        env:
-          YARN_NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -8,7 +8,12 @@ if [ -z "$VERSION" ]; then
   exit 1
 fi
 
-cd $(dirname $0)/..
+cd "$(dirname "$0")/.."
+
+if ! git diff --quiet || ! git diff --cached --quiet; then
+  echo "Error: working tree has uncommitted changes. Please commit or stash them first."
+  exit 1
+fi
 
 PACKAGES="packages/gl-react packages/gl-react-dom packages/gl-react-expo packages/gl-react-headless packages/gl-react-native"
 
@@ -18,10 +23,12 @@ for pkg in $PACKAGES; do
     const p = '$pkg/package.json';
     const d = JSON.parse(fs.readFileSync(p, 'utf8'));
     d.version = '$VERSION';
-    if (d.dependencies) {
-      if (d.dependencies['gl-react']) d.dependencies['gl-react'] = '^$VERSION';
-      if (d.dependencies['gl-react-expo']) d.dependencies['gl-react-expo'] = '^$VERSION';
-    }
+    ['dependencies', 'devDependencies'].forEach(section => {
+      if (d[section]) {
+        if (d[section]['gl-react']) d[section]['gl-react'] = '^$VERSION';
+        if (d[section]['gl-react-expo']) d[section]['gl-react-expo'] = '^$VERSION';
+      }
+    });
     fs.writeFileSync(p, JSON.stringify(d, null, 2) + '\n');
   "
   echo "Bumped $pkg to $VERSION"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+set -e
+
+VERSION=$1
+if [ -z "$VERSION" ]; then
+  echo "Usage: $0 <version>"
+  echo "Example: $0 5.3.0"
+  exit 1
+fi
+
+cd $(dirname $0)/..
+
+PACKAGES="packages/gl-react packages/gl-react-dom packages/gl-react-expo packages/gl-react-headless packages/gl-react-native"
+
+for pkg in $PACKAGES; do
+  node -e "
+    const fs = require('fs');
+    const p = '$pkg/package.json';
+    const d = JSON.parse(fs.readFileSync(p, 'utf8'));
+    d.version = '$VERSION';
+    if (d.dependencies) {
+      if (d.dependencies['gl-react']) d.dependencies['gl-react'] = '^$VERSION';
+      if (d.dependencies['gl-react-expo']) d.dependencies['gl-react-expo'] = '^$VERSION';
+    }
+    fs.writeFileSync(p, JSON.stringify(d, null, 2) + '\n');
+  "
+  echo "Bumped $pkg to $VERSION"
+done
+
+git add packages/gl-react/package.json packages/gl-react-dom/package.json packages/gl-react-expo/package.json packages/gl-react-headless/package.json packages/gl-react-native/package.json
+git commit -m "chore: release $VERSION"
+git tag "v$VERSION"
+
+echo ""
+echo "Done. Now push to trigger the publish workflow:"
+echo "  git push && git push --tags"


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/publish.yml`: publishes all 5 packages to npm automatically when a `v*` tag is pushed, using npm's **Trusted Publishers (OIDC)** — no secrets needed
- Adds `scripts/release.sh`: bumps versions across all packages (including `devDependencies`), guards against dirty working tree, commits, and creates the git tag

## Setup (one-time, already done)

Configure Trusted Publishers on npmjs.com for each of the 5 packages (`gl-react`, `gl-react-dom`, `gl-react-expo`, `gl-react-headless`, `gl-react-native`):
- Owner: `gre` / Repository: `gl-react` / Workflow: `publish.yml`

## How to release

```sh
git checkout master && git pull
./scripts/release.sh 5.3.0
git push && git push --tags
```

The workflow triggers on the tag push, builds, and publishes all 5 packages with provenance attestation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)