### PR TITLE
fix(gl-react-dom): tighten version prop type and fix getContext return type

### DIFF
--- a/packages/gl-react-dom/src/GLViewDOM.tsx
+++ b/packages/gl-react-dom/src/GLViewDOM.tsx
@@ -1,7 +1,7 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import invariant from "invariant";
-import getContext from "./getContext";
+import getContext, { GLContextVersion } from "./getContext";
 
 const __DEV__ = process.env.NODE_ENV === "development";
 
@@ -26,7 +26,7 @@ const propTypes: { [key: string]: any } = {
   height: PropTypes.number.isRequired,
   style: PropTypes.object,
   pixelRatio: PropTypes.number,
-  version: PropTypes.string,
+  version: PropTypes.oneOf(["webgl", "webgl2", "auto"]),
 };
 
 class ErrorDebug extends Component<{ error: any }> {
@@ -78,7 +78,7 @@ export default class GLViewDOM extends Component<
     height: number;
     style?: any;
     debug?: number;
-    version?: string;
+    version?: GLContextVersion;
     [key: string]: any;
   },
   {
@@ -177,8 +177,8 @@ export default class GLViewDOM extends Component<
       debug
         ? { ...webglContextAttributes, preserveDrawingBuffer: true }
         : webglContextAttributes,
-      (version || "auto") as "webgl" | "webgl2" | "auto"
-    );
+      version || "auto"
+    ) as WebGLRenderingContext | null;
     this.webglContextAttributes = webglContextAttributes || {};
     return gl;
   }

--- a/packages/gl-react-dom/src/getContext.ts
+++ b/packages/gl-react-dom/src/getContext.ts
@@ -1,23 +1,20 @@
+export type GLContextVersion = "webgl" | "webgl2" | "auto";
+
 const getContext = (
   canvas: HTMLCanvasElement,
   opts: any,
-  version: "webgl" | "webgl2" | "auto"
-) => {
-  let gl: WebGLRenderingContext | null = null;
+  version: GLContextVersion
+): WebGLRenderingContext | WebGL2RenderingContext | null => {
+  let gl: WebGLRenderingContext | WebGL2RenderingContext | null = null;
   if (version === "webgl2" || version === "auto") {
-    gl = canvas.getContext("webgl2", opts) as unknown as WebGLRenderingContext | null;
+    gl = canvas.getContext("webgl2", opts) as WebGL2RenderingContext | null;
   }
   if (!gl && (version === "webgl" || version === "auto")) {
     gl =
-      (canvas.getContext("webgl", opts) as unknown as WebGLRenderingContext | null) ||
-      (canvas.getContext(
-        "webgl-experimental" as any,
-        opts
-      ) as unknown as WebGLRenderingContext | null) ||
-      (canvas.getContext(
-        "experimental-webgl" as any,
-        opts
-      ) as unknown as WebGLRenderingContext | null);
+      (canvas.getContext("webgl", opts) as WebGLRenderingContext | null) ||
+      // non-standard context IDs require going through unknown since TypeScript's catch-all overload returns RenderingContext
+      (canvas.getContext("webgl-experimental" as any, opts) as unknown as WebGLRenderingContext | null) ||
+      (canvas.getContext("experimental-webgl" as any, opts) as unknown as WebGLRenderingContext | null);
   }
   return gl;
 };


### PR DESCRIPTION
## Summary

Addresses two issues flagged in code review on `GLViewDOM.tsx` and `getContext.ts`:

- **`version` prop type tightened** from `string` to `"webgl" | "webgl2" | "auto"` in both the TypeScript interface and `PropTypes.oneOf(...)`. This removes the need for the `as "webgl" | "webgl2" | "auto"` cast in `_createContext` and prevents unsupported values from reaching `getContext` at all.
- **`getContext` return type fixed** to `WebGLRenderingContext | WebGL2RenderingContext | null`. The `webgl2` path now casts to `WebGL2RenderingContext | null` (honest cast) rather than double-casting through `unknown` to `WebGLRenderingContext | null` which masked the real type. The `webgl` path likewise removes the unnecessary `unknown` intermediary. The non-standard `webgl-experimental`/`experimental-webgl` IDs still require `unknown` since TypeScript's catch-all overload returns `RenderingContext`.
- The `gl` field assignment in `_createContext` is cast to `WebGLRenderingContext | null` at the boundary to avoid cascading type changes into `gl-react` core (which uses `WebGLRenderingContext` throughout its rendering pipeline — WebGL2 is backward compatible in practice).

## Test plan

- [ ] `yarn typecheck` passes (verified locally via `tsc --noEmit` in `packages/gl-react-dom`)
- [ ] Passing a non-`"webgl" | "webgl2" | "auto"` string to `version` now produces a TypeScript error and a PropTypes warning at runtime

🤖 Generated with [Claude Code](https://claude.com/claude-code)