### PR TITLE
fix: gl-react-blur tsc declaration build + run full build in PR CI

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -19,9 +19,8 @@ jobs:
         node-version: 24
         cache: pnpm
     - run: pnpm install --frozen-lockfile
+    # Full build (babel + tsc -b declarations) so PRs catch type errors
+    # before the Release workflow does
     - name: Build gl-react packages
-      run: |
-        for d in packages/gl-react packages/gl-react-dom packages/gl-react-headless packages/gl-react-image packages/gl-react-blur; do
-          pnpm exec babel --root-mode upward --source-maps --extensions '.ts,.tsx' -d "$d/lib" "$d/src"
-        done
+      run: pnpm build
     - run: xvfb-run -s "-ac -screen 0 1280x1024x24" pnpm test

--- a/packages/gl-react-blur/src/Blur.tsx
+++ b/packages/gl-react-blur/src/Blur.tsx
@@ -36,6 +36,6 @@ const Blur = connectSize(
       );
     return rec(passes);
   }
-) as React.ComponentType<BlurProps>;
+) as unknown as React.ComponentType<BlurProps>;
 
 export default Blur;

--- a/packages/gl-react-blur/src/Blur1D.tsx
+++ b/packages/gl-react-blur/src/Blur1D.tsx
@@ -43,6 +43,6 @@ const Blur1D = connectSize(
       uniforms={{ t, resolution: [width, height], direction }}
     />
   )
-) as React.ComponentType<Blur1DProps>;
+) as unknown as React.ComponentType<Blur1DProps>;
 
 export default Blur1D;

--- a/packages/gl-react-blur/src/BlurV.tsx
+++ b/packages/gl-react-blur/src/BlurV.tsx
@@ -39,6 +39,6 @@ const BlurV = connectSize(
       );
     return rec(passes);
   }
-) as React.ComponentType<BlurVProps>;
+) as unknown as React.ComponentType<BlurVProps>;
 
 export default BlurV;

--- a/packages/gl-react-blur/src/BlurV1D.tsx
+++ b/packages/gl-react-blur/src/BlurV1D.tsx
@@ -45,6 +45,6 @@ const BlurV1D = connectSize(
       uniforms={{ t, map, resolution: [width, height], direction }}
     />
   )
-) as React.ComponentType<BlurV1DProps>;
+) as unknown as React.ComponentType<BlurV1DProps>;
 
 export default BlurV1D;


### PR DESCRIPTION
## Summary

Master's Release workflow is red since #514 merged: `tsc -b` rejects the `connectSize(...) as React.ComponentType<P>` casts (TS2352, insufficient overlap) — fixed with an `as unknown as` intermediate. This also blocks the first publish of `gl-react-blur@6.0.0`, which will go out when this merges.

**Why PR CI didn't catch it:** `ci-tests.yml` compiled packages with the babel loop only — `tsc -b` (declaration build) only ran in the Release workflow, on master, after merge. The PR build step now runs the full `pnpm build` (babel + tsc) so type errors fail the PR instead. (My local pre-push check also misread the build result by piping it into grep, losing the exit code — mea culpa, fixed my habits along with the workflow.)

## Verification
- `pnpm build` exit 0 (babel + tsc both clean)
- `pnpm test`: 42/42 ✅
- This PR's own `build` check now exercises the previously missing tsc step

🤖 Generated with [Claude Code](https://claude.com/claude-code)